### PR TITLE
Add latitude & longitude navigation

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -92,6 +92,20 @@ for container_name in Database["Containers"]:
         Planetary_POI_list[container_name].append(poi)
 
 
+def get_local_xyz(lat : float, long : float, height : float, Container : dict):
+    lat_rad = radians(lat)
+    long_rad = radians(-1*long)
+
+    Radius = Container["Body Radius"]
+    Radial_Distance = Radius + height
+
+    local_coordinates = {
+        "X": Radial_Distance * cos(lat_rad) * sin(long_rad),
+        "Y": Radial_Distance * cos(lat_rad) * cos(long_rad),
+        "Z": Radial_Distance * sin(lat_rad),
+    }
+
+    return local_coordinates
 
 
 parser = argparse.ArgumentParser()
@@ -154,12 +168,15 @@ if Mode == "planetary_nav":
             #
         
         else:
-            arg_lat = args.lat
-            arg_long = args.long
-            arg_height = args.height
-            #
-            # add some things here
-            #
+            local_coordinates = get_local_xyz(args.lat, args.long, args.height, Database["Containers"][arg_container])
+            Target = {
+                'Name': 'Custom POI',
+                'Container': arg_container,
+                'X': local_coordinates['X'],
+                'Y': local_coordinates['Y'],
+                'Z': local_coordinates['Z'],
+                "QTMarker": "FALSE"
+            }
 
 elif Mode == "space_nav":
     arg_known = args.known

--- a/pages/menu/menu.html
+++ b/pages/menu/menu.html
@@ -48,7 +48,7 @@
                     <option value="" disabled selected>----------------------</option>
                     <option value="xyz">X/Y/Z</option>
                     <option value="oms" disabled>OMs</option>
-                    <option value="longlatheight" disabled>Long/Lat/Height</option>
+                    <option value="longlatheight">Long/Lat/Height</option>
                 </select>
 
                 <div id="planetary_custom_poi_xyz_div" class="custom_entries_div">


### PR DESCRIPTION
Added ability to navigate to arbitrary latitude/longitude coordinates on planets and moons.

- Introduced a function `get_local_xyz` to convert lat, long, and height to X, Y, Z relative to the planet, based largely on comments on #10 , but also factoring in the height. This is called from the argument processing section to set the Target dict.

- Enabled the 'Long/Lat/Height' option in the frontend menu.

I have tested this around microTech and moons with latitudes and longitudes from verseguide.com with good results. Once closer than ~500 meters to the target there is some jitter or inaccuracy which I believe is mostly from timing (would be nice if /showlocation also provided a time in addition to coordinates).